### PR TITLE
Mistyped key for CustomerTypes hash

### DIFF
--- a/lib/shipping/ups.rb
+++ b/lib/shipping/ups.rb
@@ -423,7 +423,7 @@ module Shipping
 
 		CustomerTypes = {
 			'wholesale' => '01',
-			'ocassional' => '02',
+			'occasional' => '02',
 			'retail' => '04'
 		}
 		


### PR DESCRIPTION
I was reading through the code prior to an attempt to implement shipping gem to handle printing of return labels and found a small typo. (ocassional -> occasional)
